### PR TITLE
Updated Jenkinsfile

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
                 sh 'mvn -B -DskipTests clean package'
             }
         }


### PR DESCRIPTION
WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!